### PR TITLE
Mountargs

### DIFF
--- a/cfs/main.go
+++ b/cfs/main.go
@@ -73,6 +73,7 @@ func (NullWriter) Write([]byte) (int, error) { return 0, nil }
 
 func main() {
 
+	fusermountPath()
 	flag.Usage = printUsage
 	flag.Parse()
 	clargs := getArgs(flag.Args())
@@ -176,6 +177,16 @@ func getArgs(args []string) map[string]string {
 	clargs["cfsDevice"] = args[0]
 	clargs["mountPoint"] = args[1]
 	return clargs
+}
+
+func fusermountPath() {
+	// Grab the current path
+	currentPath := os.Getenv("PATH")
+	if len(currentPath) == 0 {
+		// using mount seem to not have a path
+		// fusermount is in /bin
+		os.Setenv("PATH", "/bin")
+	}
 }
 
 // printUsage will display usage

--- a/cfs/main.go
+++ b/cfs/main.go
@@ -128,7 +128,7 @@ func getArgs(args []string) map[string]string {
 	// Setup declarations
 	var optList []string
 	requiredOptions := []string{"host"}
-	commands := make(map[string]string)
+	clargs := make(map[string]string)
 
 	// Not the correct number of arguments or -help
 	if len(args) != 4 {
@@ -146,12 +146,17 @@ func getArgs(args []string) map[string]string {
 	if args[2] == "-o" || args[2] == "--o" {
 		optList = strings.Split(args[3], ",")
 		for _, item := range optList {
-			value := strings.Split(item, "=")
-			if value[0] == "" || value[1] == "" {
-				printUsage()
-				log.Fatalf("Invalid option %s, %s no value\n\n", value[0], value[1])
+			if strings.Contains(item, "=") {
+				value := strings.Split(item, "=")
+				if value[0] == "" || value[1] == "" {
+					printUsage()
+					log.Fatalf("Invalid option %s, %s no value\n\n", value[0], value[1])
+				} else {
+					clargs[value[0]] = value[1]
+				}
+			} else {
+				clargs[item] = ""
 			}
-			commands[value[0]] = value[1]
 		}
 	} else {
 		printUsage()
@@ -160,7 +165,7 @@ func getArgs(args []string) map[string]string {
 
 	// Verify required options exist
 	for _, v := range requiredOptions {
-		_, ok := commands[v]
+		_, ok := clargs[v]
 		if !ok {
 			printUsage()
 			log.Fatalf("%s is a required option", v)
@@ -168,9 +173,9 @@ func getArgs(args []string) map[string]string {
 	}
 
 	// load in device and mountPoint
-	commands["cfsDevice"] = args[0]
-	commands["mountPoint"] = args[1]
-	return commands
+	clargs["cfsDevice"] = args[0]
+	clargs["mountPoint"] = args[1]
+	return clargs
 }
 
 // printUsage will display usage


### PR DESCRIPTION
Changed command line argument processing to use the style of the linux "mount" command.   There is a required option list that only contains  "host=address:port.  The location of the formic api.  Additional options can be passed in but will currently be ignored. 
for example  -o rw,host=localhost:8845,debug,user_id=0

Example of mount:
ln -srf $GOPATH/bin /sbin/mount.cfs
mount -t cfs  [device] [mount point] -o [OPTIONS]

Example of cfs: 
cfs [device] [mount point] -o [OPTIONS]

Also, using when using the mount command the system has no path so if the PATH environment variable is empty "/bin" is set.
