### PR TITLE
Added a wrapper executable for cfs

### DIFF
--- a/cfswrap/README.md
+++ b/cfswrap/README.md
@@ -1,0 +1,34 @@
+## Additional Step to use the normal mount and umount commands with cfsfuse
+
+`ln -srf $GOPATH/bin/cfswrap /sbin/mount.cfs`
+
+
+## Command line format and required options
+
+    cfs device path_to_mount_point  -o [MOUNT OPTIONS]
+      Command line arguments are positional
+        device                  is currently not used
+        path_to_mount_point     is required
+        -o [List of Options]    the -o is required
+            host=[ipaddress:port]     is the required location of the formic service
+
+
+###Example to mount filesystem:
+
+* `mount -t cfs unknown /mnt/cfsdrive -o host=localhost:8445,debug`
+
+
+### Examples to unmount filesystem:
+
+* `umount /mnt/cfsdrive`
+
+* `fusermount -u /mnt/cfsdrive`
+
+* `fusermount -uz /mnt/cfsdrive`
+
+
+### Example of /etc/fstab entry
+
+    # <file system>   <mount point>      <type>  <options>                  <dump>  <pass>
+    # ...
+    unknown           /mnt/cfsdrive    cfs    rw,host=localhost:8445,debug    0       0

--- a/cfswrap/main.go
+++ b/cfswrap/main.go
@@ -1,0 +1,66 @@
+// cfswrap is a wrapper for the linux mount command
+//   to run the cfs fuse client
+//
+//
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// USER and GROUP ID for the root user
+const (
+	UID  = 0
+	GUID = 0
+)
+
+func main() {
+
+	var clargs []string
+	// Parsing command line arguments
+	flag.Parse()
+
+	// Grab the current PATH
+	path, err := exec.LookPath("cfs")
+	if err != nil {
+		log.Fatalf("failed to find the cfs program: %v", err)
+		os.Exit(1)
+	}
+
+	// Working with command line arguments to pass them thru to cfs
+	clargs = append([]string{path}, flag.Args()...)
+
+	// The Credential fields are used to set UID, GID and attitional GIDS of the process
+	// You need to run the program as  root to do this
+	var cred = &syscall.Credential{UID, GUID, []uint32{}}
+	// the Noctty flag is used to detach the process from parent tty
+	var sysproc = &syscall.SysProcAttr{Credential: cred, Noctty: true}
+	var attr = os.ProcAttr{
+		Dir: ".",
+		Env: os.Environ(),
+		Files: []*os.File{
+			os.Stdin,
+			os.Stdout,
+			os.Stderr,
+		},
+		Sys: sysproc,
+	}
+	process, err := os.StartProcess(path, clargs, &attr)
+	if err == nil {
+		fmt.Println(process.Pid)
+		// It is not clear from docs, but Realease actually detaches the process
+		err = process.Release()
+		if err != nil {
+			fmt.Println(err.Error())
+		}
+
+	} else {
+		fmt.Println(err.Error())
+	}
+}

--- a/cfswrap/main.go
+++ b/cfswrap/main.go
@@ -8,9 +8,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
-	"os/exec"
 	"syscall"
 )
 
@@ -26,12 +24,8 @@ func main() {
 	// Parsing command line arguments
 	flag.Parse()
 
-	// Grab the current PATH
-	path, err := exec.LookPath("cfs")
-	if err != nil {
-		log.Fatalf("failed to find the cfs program: %v", err)
-		os.Exit(1)
-	}
+	// Set the path to cfs
+	path := "/root/go/bin/cfs"
 
 	// Working with command line arguments to pass them thru to cfs
 	clargs = append([]string{path}, flag.Args()...)


### PR DESCRIPTION
To use the linux mount command the cfs process would need to
detach from the current terminal and tty. This program starts
the cfs process as the user described and passes thru the command
line arguments to the new program and then detaches from the
terminal session.  There is also a README.md file describing the features of this wrapper
