### PR TITLE
Integrate metrics & add cfs darwin build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ build:
 		-X main.buildDate=$(shell date -u +%Y-%m-%d.%H:%M:%S)" github.com/creiht/formic/formicd
 	go build -i -v -o packaging/root/usr/local/bin/cfswrap github.com/creiht/formic/cfswrap
 
+darwin: export GOOS=darwin
+darwin:
+	GOOS=darwin go build -i -v -o packaging/root/usr/local/bin/cfs.osx github.com/creiht/formic/cfs
+
 clean:
 	rm -rf packaging/output
 	rm -f packaging/root/usr/local/bin

--- a/formicd/config.go
+++ b/formicd/config.go
@@ -14,6 +14,8 @@ type config struct {
 	insecureSkipVerify bool
 	skipMutualTLS      bool
 	nodeId             int
+	metricsAddr        string
+	metricsCollectors  string
 }
 
 func resolveConfig(c *config) *config {
@@ -56,6 +58,12 @@ func resolveConfig(c *config) *config {
 			cfg.nodeId = val
 		}
 	}
-
+	cfg.metricsAddr = ":9100"
+	if env := os.Getenv("FORMICD_METRICS_ADDR"); env != "" {
+		cfg.metricsAddr = env
+	}
+	if env := os.Getenv("FORMICD_METRICS_COLLECTORS"); env != "" {
+		cfg.metricsCollectors = env
+	}
 	return cfg
 }


### PR DESCRIPTION
- adds two new env config opts:
  FORMICD_METRICS_ADD=someip:someport (default :9100)
  FORMICD_METRICS_COLLECTORS=collector1,collector2 (default empty)
- adds darwin build command for cfs.osx
