### PR TITLE
Add validation on commands

### DIFF
--- a/cfs/README.md
+++ b/cfs/README.md
@@ -14,7 +14,7 @@ mv cfs mount.cfs /sbin/
 cfs -T <token> create iad:// -N <fs_name>
 # grant access to the filesystem
 ifconfig
-cfs -T <token> grant iad://<fs_id> -addr <ip> 
+cfs -T <token> grant iad://<fs_id> -addr <ip>
 # mount the filesystem
 mkdir -p /mnt/<fs_name>
 echo “iad://<fs_id> /mnt/<fs_name> cfs rw 0 0” >> /etc/fstab
@@ -36,6 +36,6 @@ cfs -T <token> grant iad://<fs id> -addr <ip>
 # revoke an ip's access
 cfs -T <token> revoke iad://<fs id> -addr <ip>
 
-# Both DELETE and UPDATE file system operations are not 
+# Both DELETE and UPDATE file system operations are not
 #   implemented in at this time
 ```

--- a/cfs/main.go
+++ b/cfs/main.go
@@ -84,7 +84,7 @@ func main() {
 	}
 
 	// Process command line arguments
-	var token string
+	var gtoken string
 	var fsNum string
 	var serverAddr string
 
@@ -93,11 +93,12 @@ func main() {
 	app.Usage = "Client used to test filesysd"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
-			Name:        "token, T",
+			Name:        "token",
+			Aliases:     []string{"T"},
 			Value:       "",
 			Usage:       "Access token",
 			EnvVars:     []string{"OOHHC_TOKEN_KEY"},
-			Destination: &token,
+			Destination: &gtoken,
 		},
 	}
 	app.Commands = []cli.Command{
@@ -110,7 +111,7 @@ func main() {
 					fmt.Println("Invalid syntax for show.")
 					os.Exit(1)
 				}
-				if token == "" {
+				if gtoken == "" {
 					fmt.Println("Token is required")
 					os.Exit(1)
 				}
@@ -121,7 +122,7 @@ func main() {
 				}
 				conn := setupWS(serverAddr)
 				ws := pb.NewFileSystemAPIClient(conn)
-				result, err := ws.ShowFS(context.Background(), &pb.ShowFSRequest{Token: token, FSid: fsNum})
+				result, err := ws.ShowFS(context.Background(), &pb.ShowFSRequest{Token: gtoken, FSid: fsNum})
 				if err != nil {
 					log.Fatalf("Bad Request: %v", err)
 					conn.Close()
@@ -135,12 +136,13 @@ func main() {
 		{
 			Name:      "create",
 			Usage:     "Create a File Systems",
-			ArgsUsage: "<region>:// -N <file system name>",
+			ArgsUsage: "<region>:// [N|name] <file system name>",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "name, N",
-					Value: "",
-					Usage: "Name of the file system",
+					Name:    "name, N",
+					Aliases: []string{"N"},
+					Value:   "",
+					Usage:   "Name of the file system",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -148,7 +150,7 @@ func main() {
 					fmt.Println("Invalid syntax for show.")
 					os.Exit(1)
 				}
-				if token == "" {
+				if gtoken == "" {
 					fmt.Println("Token is required")
 				}
 				// For create serverAddr and acctnum are required
@@ -159,7 +161,7 @@ func main() {
 				}
 				conn := setupWS(serverAddr)
 				ws := pb.NewFileSystemAPIClient(conn)
-				result, err := ws.CreateFS(context.Background(), &pb.CreateFSRequest{Token: token, FSName: c.String("name")})
+				result, err := ws.CreateFS(context.Background(), &pb.CreateFSRequest{Token: gtoken, FSName: c.String("name")})
 				if err != nil {
 					log.Fatalf("Bad Request: %v", err)
 					conn.Close()
@@ -179,14 +181,14 @@ func main() {
 					fmt.Println("Invalid syntax for list.")
 					os.Exit(1)
 				}
-				if token == "" {
+				if gtoken == "" {
 					fmt.Println("Token is required")
 					os.Exit(1)
 				}
 				serverAddr, _ = parseurl(c.Args().Get(0), "8445")
 				conn := setupWS(serverAddr)
 				ws := pb.NewFileSystemAPIClient(conn)
-				result, err := ws.ListFS(context.Background(), &pb.ListFSRequest{Token: token})
+				result, err := ws.ListFS(context.Background(), &pb.ListFSRequest{Token: gtoken})
 				if err != nil {
 					log.Fatalf("Bad Request: %v", err)
 					conn.Close()
@@ -206,7 +208,7 @@ func main() {
 					fmt.Println("Invalid syntax for delete.")
 					os.Exit(1)
 				}
-				if token == "" {
+				if gtoken == "" {
 					fmt.Println("Token is required")
 				}
 				serverAddr, fsNum = parseurl(c.Args().Get(0), "8445")
@@ -216,7 +218,7 @@ func main() {
 				}
 				conn := setupWS(serverAddr)
 				ws := pb.NewFileSystemAPIClient(conn)
-				result, err := ws.DeleteFS(context.Background(), &pb.DeleteFSRequest{Token: token, FSid: fsNum})
+				result, err := ws.DeleteFS(context.Background(), &pb.DeleteFSRequest{Token: gtoken, FSid: fsNum})
 				if err != nil {
 					log.Fatalf("Bad Request: %v", err)
 					conn.Close()
@@ -233,14 +235,10 @@ func main() {
 			ArgsUsage: "<region>://<file system uuid> -o [OPTIONS]",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "name, N",
-					Value: "",
-					Usage: "Name of the file system",
-				},
-				cli.StringFlag{
-					Name:  "S, status",
-					Value: "",
-					Usage: "Status of the file system",
+					Name:    "name",
+					Aliases: []string{"N"},
+					Value:   "",
+					Usage:   "Name of the file system",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -248,7 +246,7 @@ func main() {
 					fmt.Println("Invalid syntax for update.")
 					os.Exit(1)
 				}
-				if token == "" {
+				if gtoken == "" {
 					fmt.Println("Token is required")
 					os.Exit(1)
 				}
@@ -262,12 +260,11 @@ func main() {
 					os.Exit(1)
 				}
 				fsMod := &pb.ModFS{
-					Name:   c.String("name"),
-					Status: c.String("status"),
+					Name: c.String("name"),
 				}
 				conn := setupWS(serverAddr)
 				ws := pb.NewFileSystemAPIClient(conn)
-				result, err := ws.UpdateFS(context.Background(), &pb.UpdateFSRequest{Token: token, FSid: fsNum, Filesys: fsMod})
+				result, err := ws.UpdateFS(context.Background(), &pb.UpdateFSRequest{Token: gtoken, FSid: fsNum, Filesys: fsMod})
 				if err != nil {
 					log.Fatalf("Bad Request: %v", err)
 					conn.Close()
@@ -294,7 +291,7 @@ func main() {
 					fmt.Println("Invalid syntax for delete.")
 					os.Exit(1)
 				}
-				if token == "" {
+				if gtoken == "" {
 					fmt.Println("Token is required")
 					os.Exit(1)
 				}
@@ -309,7 +306,7 @@ func main() {
 				}
 				conn := setupWS(serverAddr)
 				ws := pb.NewFileSystemAPIClient(conn)
-				result, err := ws.GrantAddrFS(context.Background(), &pb.GrantAddrFSRequest{Token: token, FSid: fsNum, Addr: c.String("addr")})
+				result, err := ws.GrantAddrFS(context.Background(), &pb.GrantAddrFSRequest{Token: gtoken, FSid: fsNum, Addr: c.String("addr")})
 				if err != nil {
 					log.Fatalf("Bad Request: %v", err)
 					conn.Close()
@@ -336,7 +333,7 @@ func main() {
 					fmt.Println("Invalid syntax for revoke.")
 					os.Exit(1)
 				}
-				if token == "" {
+				if gtoken == "" {
 					fmt.Println("Token is required")
 					os.Exit(1)
 				}
@@ -351,7 +348,7 @@ func main() {
 				}
 				conn := setupWS(serverAddr)
 				ws := pb.NewFileSystemAPIClient(conn)
-				result, err := ws.RevokeAddrFS(context.Background(), &pb.RevokeAddrFSRequest{Token: token, FSid: fsNum, Addr: c.String("addr")})
+				result, err := ws.RevokeAddrFS(context.Background(), &pb.RevokeAddrFSRequest{Token: gtoken, FSid: fsNum, Addr: c.String("addr")})
 				if err != nil {
 					log.Fatalf("Bad Request: %v", err)
 					conn.Close()

--- a/cfs/main.go
+++ b/cfs/main.go
@@ -204,10 +204,6 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				if !c.Args().Present() {
-					fmt.Println("Invalid syntax for list.")
-					os.Exit(1)
-				}
 				if gtoken == "" {
 					fmt.Println("Token is required")
 					os.Exit(1)

--- a/cfs/main.go
+++ b/cfs/main.go
@@ -139,7 +139,7 @@ func main() {
 			ArgsUsage: "<region>:// [N|name] <file system name>",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:    "name, N",
+					Name:    "name",
 					Aliases: []string{"N"},
 					Value:   "",
 					Usage:   "Name of the file system",

--- a/cfs/main.go
+++ b/cfs/main.go
@@ -163,10 +163,6 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				if !c.Args().Present() {
-					fmt.Println("Invalid syntax for show.")
-					os.Exit(1)
-				}
 				if gtoken == "" {
 					fmt.Println("Token is required")
 				}

--- a/cfs/main.go
+++ b/cfs/main.go
@@ -13,13 +13,13 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/codegangsta/cli"
 	pb "github.com/creiht/formic/proto"
 	"github.com/getcfs/fuse"
 	"github.com/pkg/profile"
 	"github.com/satori/go.uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"gopkg.in/urfave/cli.v2"
 )
 
 type server struct {
@@ -96,7 +96,7 @@ func main() {
 			Name:        "token, T",
 			Value:       "",
 			Usage:       "Access token",
-			EnvVar:      "OOHHC_TOKEN_KEY",
+			EnvVars:     []string{"OOHHC_TOKEN_KEY"},
 			Destination: &token,
 		},
 	}

--- a/cfs/main.go
+++ b/cfs/main.go
@@ -87,6 +87,8 @@ func main() {
 	var gtoken string
 	var fsNum string
 	var serverAddr string
+	var fsName string
+	var addrValue string
 
 	app := cli.NewApp()
 	app.Name = "cfs"
@@ -139,10 +141,11 @@ func main() {
 			ArgsUsage: "<region>:// [N|name] <file system name>",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:    "name",
-					Aliases: []string{"N"},
-					Value:   "",
-					Usage:   "Name of the file system",
+					Name:        "name",
+					Aliases:     []string{"N"},
+					Value:       "",
+					Usage:       "Name of the file system",
+					Destination: &fsName,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -155,13 +158,13 @@ func main() {
 				}
 				// For create serverAddr and acctnum are required
 				serverAddr, _ = parseurl(c.Args().Get(0), "8445")
-				if c.String("name") == "" {
+				if fsName == "" {
 					fmt.Println("File system name is a required field.")
 					os.Exit(1)
 				}
 				conn := setupWS(serverAddr)
 				ws := pb.NewFileSystemAPIClient(conn)
-				result, err := ws.CreateFS(context.Background(), &pb.CreateFSRequest{Token: gtoken, FSName: c.String("name")})
+				result, err := ws.CreateFS(context.Background(), &pb.CreateFSRequest{Token: gtoken, FSName: fsName})
 				if err != nil {
 					log.Fatalf("Bad Request: %v", err)
 					conn.Close()
@@ -235,10 +238,11 @@ func main() {
 			ArgsUsage: "<region>://<file system uuid> -o [OPTIONS]",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:    "name",
-					Aliases: []string{"N"},
-					Value:   "",
-					Usage:   "Name of the file system",
+					Name:        "name",
+					Aliases:     []string{"N"},
+					Value:       "",
+					Usage:       "Name of the file system",
+					Destination: &fsName,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -255,8 +259,8 @@ func main() {
 					fmt.Println("Missing file system id")
 					os.Exit(1)
 				}
-				if c.String("name") != "" {
-					fmt.Printf("Invalid File System String: %q\n", c.String("name"))
+				if fsName != "" {
+					fmt.Printf("Invalid File System String: %q\n", fsName)
 					os.Exit(1)
 				}
 				fsMod := &pb.ModFS{
@@ -281,9 +285,10 @@ func main() {
 			ArgsUsage: "<region>://<file system uuid> -addr <IP Address>",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "addr",
-					Value: "",
-					Usage: "Address to Grant",
+					Name:        "addr",
+					Value:       "",
+					Usage:       "Address to Grant",
+					Destination: &addrValue,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -295,7 +300,7 @@ func main() {
 					fmt.Println("Token is required")
 					os.Exit(1)
 				}
-				if c.String("addr") == "" {
+				if addrValue == "" {
 					fmt.Println("addr is required")
 					os.Exit(1)
 				}
@@ -306,7 +311,7 @@ func main() {
 				}
 				conn := setupWS(serverAddr)
 				ws := pb.NewFileSystemAPIClient(conn)
-				result, err := ws.GrantAddrFS(context.Background(), &pb.GrantAddrFSRequest{Token: gtoken, FSid: fsNum, Addr: c.String("addr")})
+				result, err := ws.GrantAddrFS(context.Background(), &pb.GrantAddrFSRequest{Token: gtoken, FSid: fsNum, Addr: addrValue})
 				if err != nil {
 					log.Fatalf("Bad Request: %v", err)
 					conn.Close()
@@ -323,9 +328,10 @@ func main() {
 			ArgsUsage: "<region>://<file system uuid> -addr <IP Address>",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "addr",
-					Value: "",
-					Usage: "Address to Revoke",
+					Name:        "addr",
+					Value:       "",
+					Usage:       "Address to Revoke",
+					Destination: &addrValue,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -337,7 +343,7 @@ func main() {
 					fmt.Println("Token is required")
 					os.Exit(1)
 				}
-				if c.String("addr") == "" {
+				if addrValue == "" {
 					fmt.Println("addr is required")
 					os.Exit(1)
 				}
@@ -348,7 +354,7 @@ func main() {
 				}
 				conn := setupWS(serverAddr)
 				ws := pb.NewFileSystemAPIClient(conn)
-				result, err := ws.RevokeAddrFS(context.Background(), &pb.RevokeAddrFSRequest{Token: gtoken, FSid: fsNum, Addr: c.String("addr")})
+				result, err := ws.RevokeAddrFS(context.Background(), &pb.RevokeAddrFSRequest{Token: gtoken, FSid: fsNum, Addr: addrValue})
 				if err != nil {
 					log.Fatalf("Bad Request: %v", err)
 					conn.Close()


### PR DESCRIPTION
Now commands show, grant and revoke validate that the token and files system uuid are on the same account.   

Changed command create and list to use an option [R|region] instead of region://
Example original create:

```
cfs -T <token> create [aio|iad]:// [N|name] <file system name>
```

New:

```
cfs -T <token> create  [R|region] [aio|iad] [N|name] <file system name>
```

Example original list:

```
cfs -T <token> list [aio|iad]:// 
```

New:

```
cfs -T <token> list  [R|region] [aio|iad] 
```

Switched the cli library from codegangsta to urfave.  This lib is still under development so I had change the command argument order.   Options have to pre seed arguments.  
For example on grant and revoke:

```
cfs -T <token> grant -addr <IP ADDRESS>  [aio|iad]://<file system uuid>
cfs -T <token> revoke -addr <IP ADDRESS>  [aio|iad]://<file system uuid>
```
